### PR TITLE
fix: std.join can only join strings

### DIFF
--- a/net.jsonnet
+++ b/net.jsonnet
@@ -9,7 +9,7 @@ local string = import "string.jsonnet";
                                 function(x) iparts[x] << 8*(std.length(parts)-x-1)),
                   0),
     int_to_ip(int)::
-        std.join(".", std.makeArray(4, function(x) int >> 8*(4-x-1) & 255)),
+        std.join(".", std.makeArray(4, function(x) std.toString(int >> 8*(4-x-1) & 255))),
 
     cidr_to_list(cidr)::
         local s = std.split(cidr, "/");


### PR DESCRIPTION
Fixes 
```
RUNTIME ERROR: expected string but arr[0] was number
        jsonnet-lib/cidr.libsonnet:19:9-76      function <func>
        std.jsonnet:259:50-62   thunk <array_element>
        During manifestation
```